### PR TITLE
feat: dialog component fixed and zoom implemented

### DIFF
--- a/src/components/dashboard/Dashboard.jsx
+++ b/src/components/dashboard/Dashboard.jsx
@@ -1,12 +1,39 @@
 // src/components/Dashboard/Dashboard.jsx
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState, useCallback, useEffect, useMemo } from "react";
 import DataTable from "../Table/DataTable";
 import Graph from "../graph/Graph";
 import EditPointDialog from "../dialog/EditPointDialog";
 
+const STORAGE_NS = "igd:points:v1";
+const getKey = (user) => `${STORAGE_NS}:${user?.uid || "anon"}`;
+
+const SAMPLE = [
+  { id: "1", x: 10, y: 20 },
+  { id: "2", x: 25, y: 35 },
+  { id: "3", x: 40, y: 45 },
+  { id: "4", x: 55, y: 30 },
+  { id: "5", x: 70, y: 60 },
+];
+
+const safeParse = (raw) => {
+  try {
+    const v = JSON.parse(raw);
+    return Array.isArray(v) ? v : null;
+  } catch {
+    return null;
+  }
+};
+
 const Dashboard = ({ user, onLogout }) => {
-  // State management for points and UI
-  const [points, setPoints] = useState([]);
+  // Load initial points from localStorage (per user), else fall back to SAMPLE
+  const [points, setPoints] = useState(() => {
+    if (typeof window === "undefined") return SAMPLE;
+    const saved = safeParse(localStorage.getItem(getKey(user)));
+    return saved ?? SAMPLE;
+  });
+
+  const storageKey = useMemo(() => getKey(user), [user?.uid]);
+
   const [editingPoint, setEditingPoint] = useState(null);
   const [highlightedPoint, setHighlightedPoint] = useState(null);
   const [notification, setNotification] = useState({
@@ -14,82 +41,94 @@ const Dashboard = ({ user, onLogout }) => {
     message: "",
   });
 
-  // Initialize with sample data
+  // Persist whenever points change
   useEffect(() => {
-    const samplePoints = [
-      { id: "1", x: 10, y: 20 },
-      { id: "2", x: 25, y: 35 },
-      { id: "3", x: 40, y: 45 },
-      { id: "4", x: 55, y: 30 },
-      { id: "5", x: 70, y: 60 },
-    ];
-    setPoints(samplePoints);
-  }, []);
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(points));
+    } catch {}
+  }, [points, storageKey]);
 
-  // Show notification
+  // When the user changes (different storageKey), load their saved points or SAMPLE
+  useEffect(() => {
+    const saved = safeParse(localStorage.getItem(storageKey));
+    setPoints(saved ?? SAMPLE);
+  }, [storageKey]);
+
+  // Optional: keep multiple tabs/windows in sync
+  useEffect(() => {
+    const onStorage = (e) => {
+      if (e.key === storageKey) {
+        const saved = safeParse(e.newValue);
+        if (saved) setPoints(saved);
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, [storageKey]);
+
   const showNotification = (message) => {
     setNotification({ show: true, message });
     setTimeout(() => setNotification({ show: false, message: "" }), 3000);
   };
 
-  // Handle points change from graph
-  const handlePointsChange = useCallback((newPoints) => {
-    setPoints(newPoints);
-  }, []);
+  const handlePointsChange = useCallback(
+    (newPoints) => setPoints(newPoints),
+    []
+  );
 
-  // Handle point edit from table
+  // Open editor (from table or graph)
   const handlePointEdit = useCallback((point) => {
     setEditingPoint(point);
+    setHighlightedPoint(point?.id ?? null);
   }, []);
 
-  // Handle point save from dialog
-  const handlePointSave = useCallback((updatedPoint) => {
-    setPoints((prevPoints) =>
-      prevPoints.map((point) =>
-        point.id === updatedPoint.id ? updatedPoint : point
+  // Live updates from popup while typing
+  const handleDialogLiveChange = useCallback((updated) => {
+    setPoints((prev) =>
+      prev.map((p) =>
+        p.id === updated.id ? { ...p, x: updated.x, y: updated.y } : p
       )
+    );
+    setHighlightedPoint(updated.id);
+  }, []);
+
+  // Save from popup
+  const handlePointSave = useCallback((updatedPoint) => {
+    setPoints((prev) =>
+      prev.map((p) => (p.id === updatedPoint.id ? updatedPoint : p))
     );
     showNotification("Point updated successfully");
   }, []);
 
-  // Handle point delete from table
   const handlePointDelete = useCallback(
     (pointId) => {
-      setPoints((prevPoints) =>
-        prevPoints.filter((point) => point.id !== pointId)
-      );
+      setPoints((prev) => prev.filter((p) => p.id !== pointId));
+      if (highlightedPoint === pointId) setHighlightedPoint(null);
+      if (editingPoint?.id === pointId) setEditingPoint(null);
       showNotification("Point deleted successfully");
-      if (highlightedPoint === pointId) {
-        setHighlightedPoint(null);
-      }
     },
-    [highlightedPoint]
+    [highlightedPoint, editingPoint]
   );
 
-  // Handle dialog close
-  const handleEditDialogClose = useCallback(() => {
-    setEditingPoint(null);
-  }, []);
+  const handleEditDialogClose = useCallback(() => setEditingPoint(null), []);
+  const handlePointHover = useCallback(
+    (pointId) => setHighlightedPoint(pointId),
+    []
+  );
+  const handlePointClick = useCallback(
+    (point) => handlePointEdit(point),
+    [handlePointEdit]
+  );
 
-  // Handle hover events
-  const handlePointHover = useCallback((pointId) => {
-    setHighlightedPoint(pointId);
-  }, []);
-
-  // Handle point click from graph
-  const handlePointClick = useCallback((point) => {
-    setEditingPoint(point);
-  }, []);
-
-  // Handle clear all points
   const handleClearAll = () => {
     if (window.confirm("Are you sure you want to clear all points?")) {
       setPoints([]);
+      setHighlightedPoint(null);
+      setEditingPoint(null);
       showNotification("All points cleared");
     }
   };
 
-  // Styles
   const styles = {
     container: {
       padding: "20px",
@@ -107,30 +146,11 @@ const Dashboard = ({ user, onLogout }) => {
       borderRadius: "12px",
       boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
     },
-    userInfo: {
-      display: "flex",
-      alignItems: "center",
-      gap: "15px",
-    },
-    avatar: {
-      width: "50px",
-      height: "50px",
-      borderRadius: "50%",
-    },
-    title: {
-      margin: 0,
-      fontSize: "24px",
-      fontWeight: "bold",
-    },
-    subtitle: {
-      margin: 0,
-      color: "#666",
-      fontSize: "14px",
-    },
-    headerButtons: {
-      display: "flex",
-      gap: "10px",
-    },
+    userInfo: { display: "flex", alignItems: "center", gap: "15px" },
+    avatar: { width: "50px", height: "50px", borderRadius: "50%" },
+    title: { margin: 0, fontSize: "24px", fontWeight: "bold" },
+    subtitle: { margin: 0, color: "#666", fontSize: "14px" },
+    headerButtons: { display: "flex", gap: "10px" },
     clearButton: {
       padding: "10px 20px",
       backgroundColor: "#6c757d",
@@ -149,11 +169,7 @@ const Dashboard = ({ user, onLogout }) => {
       cursor: "pointer",
       fontWeight: "500",
     },
-    grid: {
-      display: "grid",
-      gridTemplateColumns: "2fr 1fr",
-      gap: "30px",
-    },
+    grid: { display: "grid", gridTemplateColumns: "2fr 1fr", gap: "30px" },
     card: {
       backgroundColor: "white",
       padding: "20px",
@@ -175,10 +191,7 @@ const Dashboard = ({ user, onLogout }) => {
       justifyContent: "center",
       alignItems: "center",
     },
-    tableContainer: {
-      flex: 1,
-      overflow: "auto",
-    },
+    tableContainer: { flex: 1, overflow: "auto" },
     notification: {
       position: "fixed",
       bottom: "20px",
@@ -199,25 +212,6 @@ const Dashboard = ({ user, onLogout }) => {
       fontSize: "14px",
       textAlign: "center",
     },
-    "@keyframes slideIn": {
-      from: {
-        transform: "translateX(100%)",
-        opacity: 0,
-      },
-      to: {
-        transform: "translateX(0)",
-        opacity: 1,
-      },
-    },
-  };
-
-  // Add responsive styles for mobile
-  const mobileStyles = {
-    "@media (max-width: 768px)": {
-      grid: {
-        gridTemplateColumns: "1fr",
-      },
-    },
   };
 
   return (
@@ -225,13 +219,13 @@ const Dashboard = ({ user, onLogout }) => {
       {/* Header */}
       <div style={styles.header}>
         <div style={styles.userInfo}>
-          {user.photoURL && (
+          {user?.photoURL && (
             <img src={user.photoURL} alt="Profile" style={styles.avatar} />
           )}
           <div>
             <h1 style={styles.title}>Interactive Graph Dashboard</h1>
             <p style={styles.subtitle}>
-              Welcome back, {user.displayName || user.email}
+              Welcome back, {user?.displayName || user?.email}
             </p>
           </div>
         </div>
@@ -256,9 +250,12 @@ const Dashboard = ({ user, onLogout }) => {
               onPointsChange={handlePointsChange}
               highlightedPoint={highlightedPoint}
               onPointHover={handlePointHover}
-              onPointClick={handlePointClick}
+              onPointClick={handlePointEdit}
               width={700}
               height={500}
+              // Optional extras:
+              // scaleMode="auto"
+              // zoomScaleExtent={[0.5, 40]}
             />
           </div>
         </div>
@@ -273,18 +270,22 @@ const Dashboard = ({ user, onLogout }) => {
               onPointDelete={handlePointDelete}
               highlightedPoint={highlightedPoint}
               onRowHover={handlePointHover}
+              // numberFormatter={...} // optional override for display/tooltip formatting
             />
           </div>
           <div style={styles.pointsCounter}>Total Points: {points.length}</div>
         </div>
       </div>
 
-      {/* Edit Dialog */}
+      {/* Popup Editor (live updates enabled) */}
       <EditPointDialog
         open={!!editingPoint}
         point={editingPoint}
         onClose={handleEditDialogClose}
         onSave={handlePointSave}
+        onLiveChange={handleDialogLiveChange}
+        // bounds={{minX:-1e9,maxX:1e9,minY:-1e9,maxY:1e9}} // optional hint/limits
+        // enforceBounds={false}
       />
 
       {/* Notification */}
@@ -292,22 +293,10 @@ const Dashboard = ({ user, onLogout }) => {
         <div style={styles.notification}>{notification.message}</div>
       )}
 
-      {/* Add keyframes style to document */}
       <style>{`
         @keyframes slideIn {
-          from {
-            transform: translateX(100%);
-            opacity: 0;
-          }
-          to {
-            transform: translateX(0);
-            opacity: 1;
-          }
-        }
-        @media (max-width: 768px) {
-          .dashboard-grid {
-            grid-template-columns: 1fr !important;
-          }
+          from { transform: translateX(100%); opacity: 0; }
+          to   { transform: translateX(0);    opacity: 1; }
         }
       `}</style>
     </div>

--- a/src/components/table/DataTable.jsx
+++ b/src/components/table/DataTable.jsx
@@ -1,142 +1,124 @@
-import React, { memo, useCallback, useRef, useEffect } from "react";
+import React, { memo, useRef, useEffect, useCallback } from "react";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
-  IconButton,
-  Box,
-  Typography,
-  Tooltip,
-  Fade,
+  Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
+  Paper, IconButton, Box, Typography, Tooltip, Fade,
 } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
-import { usePoints } from "../../hooks/usePoints";
+import PropTypes from "prop-types";
 
-// Memoized table row component with ref for auto-scroll
-const TableRowComponent = memo(
-  ({ point, isHighlighted, onHover, onEdit, onDelete, rowRef }) => {
-    const handleMouseEnter = useCallback(
-      () => onHover(point.id),
-      [onHover, point.id]
-    );
-    const handleMouseLeave = useCallback(() => onHover(null), [onHover]);
-    const handleEdit = useCallback(
-      (e) => {
-        e.stopPropagation();
-        onEdit(point);
-      },
-      [onEdit, point]
-    );
-    const handleDelete = useCallback(
-      (e) => {
-        e.stopPropagation();
-        onDelete(point.id);
-      },
-      [onDelete, point.id]
-    );
+// Defaults: compact display, full value in tooltip
+const defaultDisplay = new Intl.NumberFormat(undefined, {
+  notation: "compact",
+  maximumFractionDigits: 2,
+});
+const defaultFull = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 2,
+});
+const defaultNumberFormatter = {
+  display: (n) => defaultDisplay.format(n),
+  tooltip: (n) => defaultFull.format(n),
+};
 
-    return (
-      <TableRow
-        ref={rowRef}
-        hover
-        selected={isHighlighted}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        sx={{
-          cursor: "pointer",
-          backgroundColor: isHighlighted ? "action.hover" : "inherit",
-          "&:hover": {
-            backgroundColor: "action.hover",
-          },
-          transition: "background-color 0.2s ease",
-        }}
-      >
-        <TableCell align="center">
-          <Typography variant="caption" sx={{ fontFamily: "monospace" }}>
-            {point.id.slice(-8)}
-          </Typography>
-        </TableCell>
-        <TableCell align="center">
-          <Typography variant="body2">{point.x.toFixed(2)}</Typography>
-        </TableCell>
-        <TableCell align="center">
-          <Typography variant="body2">{point.y.toFixed(2)}</Typography>
-        </TableCell>
-        <TableCell align="center">
-          <Tooltip title="Edit coordinates">
-            <IconButton
-              size="small"
-              color="primary"
-              onClick={handleEdit}
-              aria-label="edit point"
-            >
-              <EditIcon fontSize="small" />
-            </IconButton>
-          </Tooltip>
-          <Tooltip title="Delete point">
-            <IconButton
-              size="small"
-              color="error"
-              onClick={handleDelete}
-              aria-label="delete point"
-            >
-              <DeleteIcon fontSize="small" />
-            </IconButton>
-          </Tooltip>
-        </TableCell>
-      </TableRow>
-    );
-  }
-);
+// Row
+const TableRowComponent = memo(function TableRowComponent({
+  point,
+  isHighlighted,
+  onHover,
+  onEdit,
+  onDelete,
+  rowRef,
+  numberFormatter,
+}) {
+  const handleMouseEnter = useCallback(() => onHover?.(point.id), [onHover, point.id]);
+  const handleMouseLeave = useCallback(() => onHover?.(null), [onHover]);
+  const handleEdit = useCallback((e) => { e.stopPropagation(); onEdit?.(point); }, [onEdit, point]);
+  const handleDelete = useCallback((e) => { e.stopPropagation(); onDelete?.(point.id); }, [onDelete, point.id]);
 
-TableRowComponent.displayName = "TableRowComponent";
+  const fmtDisp = numberFormatter?.display || defaultNumberFormatter.display;
+  const fmtTip = numberFormatter?.tooltip || defaultNumberFormatter.tooltip;
 
-const DataTable = () => {
-  const {
-    points,
-    highlightedPoint,
-    pointsCount,
-    deletePoint,
-    highlightPoint,
-    clearHighlight,
-    startEditingPoint,
-  } = usePoints();
+  return (
+    <TableRow
+      ref={rowRef}
+      hover
+      selected={isHighlighted}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      sx={{
+        cursor: "pointer",
+        backgroundColor: isHighlighted ? "action.hover" : "inherit",
+        "&:hover": { backgroundColor: "action.hover" },
+        transition: "background-color 0.2s ease",
+      }}
+    >
+      <TableCell align="center">
+        <Typography variant="caption" sx={{ fontFamily: "monospace" }}>
+          {String(point.id).slice(-8)}
+        </Typography>
+      </TableCell>
+      <TableCell align="center">
+        <Tooltip title={fmtTip(point.x)}>
+          <Typography variant="body2">{fmtDisp(point.x)}</Typography>
+        </Tooltip>
+      </TableCell>
+      <TableCell align="center">
+        <Tooltip title={fmtTip(point.y)}>
+          <Typography variant="body2">{fmtDisp(point.y)}</Typography>
+        </Tooltip>
+      </TableCell>
+      <TableCell align="center">
+        <Tooltip title="Edit coordinates">
+          <IconButton size="small" color="primary" onClick={handleEdit} aria-label="edit point">
+            <EditIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Delete point">
+          <IconButton size="small" color="error" onClick={handleDelete} aria-label="delete point">
+            <DeleteIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </TableCell>
+    </TableRow>
+  );
+});
 
-  // Container + per-row refs for auto-scroll
+TableRowComponent.propTypes = {
+  point: PropTypes.shape({ id: PropTypes.any, x: PropTypes.number, y: PropTypes.number }).isRequired,
+  isHighlighted: PropTypes.bool,
+  onHover: PropTypes.func,
+  onEdit: PropTypes.func,
+  onDelete: PropTypes.func,
+  rowRef: PropTypes.any,
+  numberFormatter: PropTypes.shape({
+    display: PropTypes.func,
+    tooltip: PropTypes.func,
+  }),
+};
+
+// Table
+/**
+ * Pure, plugin-style table.
+ * Props:
+ *  - points: Array<{ id, x, y }>
+ *  - highlightedPoint: string|null
+ *  - onRowHover(id|null)
+ *  - onPointEdit(point)
+ *  - onPointDelete(id)
+ *  - numberFormatter?: { display(n)=>string, tooltip?(n)=>string }
+ */
+const DataTable = memo(function DataTable({
+  points,
+  highlightedPoint,
+  onRowHover,
+  onPointEdit,
+  onPointDelete,
+  numberFormatter = defaultNumberFormatter,
+}) {
   const containerRef = useRef(null);
-  const rowRefs = useRef({}); // { [pointId]: HTMLTableRowElement }
+  const rowRefs = useRef({}); // { [id]: HTMLTableRowElement }
 
-  const handleRowHover = useCallback(
-    (pointId) => {
-      if (pointId) {
-        highlightPoint(pointId);
-      } else {
-        clearHighlight();
-      }
-    },
-    [highlightPoint, clearHighlight]
-  );
-
-  const handlePointEdit = useCallback(
-    (point) => {
-      startEditingPoint(point);
-    },
-    [startEditingPoint]
-  );
-
-  const handlePointDelete = useCallback(
-    (pointId) => {
-      deletePoint(pointId);
-    },
-    [deletePoint]
-  );
-
-  // Auto-scroll to highlighted row when highlight changes (from graph/table)
+  // Auto-scroll to highlighted row
   useEffect(() => {
     if (!highlightedPoint) return;
     const container = containerRef.current;
@@ -148,23 +130,16 @@ const DataTable = () => {
     const visibleTop = container.scrollTop;
     const visibleBottom = visibleTop + container.clientHeight;
 
-    // If the row is outside the visible area, scroll it into view (centered)
     if (rowTop < visibleTop || rowBottom > visibleBottom) {
-      const targetTop =
-        rowTop - container.clientHeight / 2 + rowEl.offsetHeight / 2;
+      const targetTop = rowTop - container.clientHeight / 2 + rowEl.offsetHeight / 2;
       container.scrollTo({ top: Math.max(0, targetTop), behavior: "smooth" });
     }
   }, [highlightedPoint]);
 
   return (
-    <Paper
-      elevation={3}
-      sx={{ height: "100%", display: "flex", flexDirection: "column" }}
-    >
+    <Paper elevation={3} sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
       <Box sx={{ p: 2, borderBottom: "1px solid rgba(224, 224, 224, 1)" }}>
-        <Typography variant="h6" component="div">
-          Data Points Table
-        </Typography>
+        <Typography variant="h6" component="div">Data Points Table</Typography>
         <Typography variant="caption" color="text.secondary">
           Hover to highlight • Click edit to modify coordinates
         </Typography>
@@ -174,59 +149,28 @@ const DataTable = () => {
         <Table stickyHeader size="small">
           <TableHead>
             <TableRow>
-              <TableCell
-                align="center"
-                sx={{
-                  fontWeight: "bold",
-                  width: "30%",
-                  bgcolor: "background.paper",
-                }}
-              >
+              <TableCell align="center" sx={{ fontWeight: "bold", width: "30%", bgcolor: "background.paper" }}>
                 Point ID
               </TableCell>
-              <TableCell
-                align="center"
-                sx={{
-                  fontWeight: "bold",
-                  width: "20%",
-                  bgcolor: "background.paper",
-                }}
-              >
+              <TableCell align="center" sx={{ fontWeight: "bold", width: "20%", bgcolor: "background.paper" }}>
                 X Coordinate
               </TableCell>
-              <TableCell
-                align="center"
-                sx={{
-                  fontWeight: "bold",
-                  width: "20%",
-                  bgcolor: "background.paper",
-                }}
-              >
+              <TableCell align="center" sx={{ fontWeight: "bold", width: "20%", bgcolor: "background.paper" }}>
                 Y Coordinate
               </TableCell>
-              <TableCell
-                align="center"
-                sx={{
-                  fontWeight: "bold",
-                  width: "30%",
-                  bgcolor: "background.paper",
-                }}
-              >
+              <TableCell align="center" sx={{ fontWeight: "bold", width: "30%", bgcolor: "background.paper" }}>
                 Actions
               </TableCell>
             </TableRow>
           </TableHead>
+
           <TableBody>
             {points.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={4} align="center">
                   <Fade in timeout={500}>
                     <Box sx={{ py: 5 }}>
-                      <Typography
-                        variant="body2"
-                        color="text.secondary"
-                        sx={{ mb: 1 }}
-                      >
+                      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
                         No data points yet
                       </Typography>
                       <Typography variant="caption" color="text.secondary">
@@ -237,16 +181,17 @@ const DataTable = () => {
                 </TableCell>
               </TableRow>
             ) : (
-              points.map((point) => (
+              points.map((p) => (
                 <TableRowComponent
-                  key={point.id}
-                  point={point}
-                  isHighlighted={highlightedPoint === point.id}
-                  onHover={handleRowHover}
-                  onEdit={handlePointEdit}
-                  onDelete={handlePointDelete}
+                  key={p.id}
+                  point={p}
+                  isHighlighted={highlightedPoint === p.id}
+                  onHover={onRowHover}
+                  onEdit={onPointEdit}
+                  onDelete={onPointDelete}
+                  numberFormatter={numberFormatter}
                   rowRef={(el) => {
-                    if (el) rowRefs.current[point.id] = el;
+                    if (el) rowRefs.current[p.id] = el;
                   }}
                 />
               ))
@@ -255,7 +200,7 @@ const DataTable = () => {
         </Table>
       </TableContainer>
 
-      {pointsCount > 0 && (
+      {points.length > 0 && (
         <Box
           sx={{
             p: 1.5,
@@ -267,9 +212,9 @@ const DataTable = () => {
           }}
         >
           <Typography variant="caption" color="text.secondary">
-            Total Points: {pointsCount}
+            Total Points: {points.length}
           </Typography>
-          {pointsCount > 10 && (
+          {points.length > 10 && (
             <Typography variant="caption" color="text.secondary">
               Scroll to see more
             </Typography>
@@ -278,6 +223,20 @@ const DataTable = () => {
       )}
     </Paper>
   );
+});
+
+DataTable.propTypes = {
+  points: PropTypes.arrayOf(
+    PropTypes.shape({ id: PropTypes.any.isRequired, x: PropTypes.number, y: PropTypes.number })
+  ).isRequired,
+  highlightedPoint: PropTypes.any,
+  onRowHover: PropTypes.func,
+  onPointEdit: PropTypes.func,
+  onPointDelete: PropTypes.func,
+  numberFormatter: PropTypes.shape({
+    display: PropTypes.func,
+    tooltip: PropTypes.func,
+  }),
 };
 
-export default memo(DataTable);
+export default DataTable;


### PR DESCRIPTION
- Added auto-pan logic to Graph so that whenever a point is highlighted
  from the DataTable, the graph automatically centers or pans to bring
  it into view, even when zoomed in or panned away.
- Introduced visibility checks using point radius to avoid cases where
  the highlight marker was clipped or rendered outside of the viewport.
- Rendered the orange highlight marker outside of the clipPath in an
  overlay <svg>, ensuring the selected point is always visible regardless
  of zoom/pan or clipping.
- Maintained all existing interactions (drag, double-click to add)
  while improving UX consistency between the table and graph views.
